### PR TITLE
Refactored test for CSS introduction page and added a test for HTML introduction page

### DIFF
--- a/cypress/integration/learn/introductionPages.js
+++ b/cypress/integration/learn/introductionPages.js
@@ -1,0 +1,32 @@
+export function introductionPageTests(
+  testTitle,
+  pageTitle,
+  locations,
+  selectors,
+  lessonNames
+) {
+  const warningMessage =
+    'Note: Some browser extensions may interfere with elements on the page. ' +
+    'If the tests fail, try disabling your extensions for the most reliable ' +
+    'experience.';
+  describe(`Basic ${testTitle} Introduction page`, function() {
+    it('renders', () => {
+      cy.visit(locations.index);
+
+      cy.title().should('eq', pageTitle);
+    });
+
+    if (selectors.warningMessage) {
+      it('renders a warning user about extensions', () => {
+        cy.visit(locations.index);
+        cy.get(selectors.warningMessage).contains(warningMessage);
+      });
+    }
+
+    it('renders a lesson index', () => {
+      lessonNames.forEach(name => {
+        cy.get(selectors.tableOfContents).contains('span', name);
+      });
+    });
+  });
+}

--- a/cypress/integration/learn/introductionPages.js
+++ b/cypress/integration/learn/introductionPages.js
@@ -9,10 +9,10 @@ export function introductionPageTests(
     'Note: Some browser extensions may interfere with elements on the page. ' +
     'If the tests fail, try disabling your extensions for the most reliable ' +
     'experience.';
+
   describe(`Basic ${testTitle} Introduction page`, function() {
     it('renders', () => {
       cy.visit(locations.index);
-
       cy.title().should('eq', pageTitle);
     });
 

--- a/cypress/integration/learn/responsive-web-design/basic-css/index.js
+++ b/cypress/integration/learn/responsive-web-design/basic-css/index.js
@@ -60,23 +60,4 @@ const lessonNames = [
   'Use a media query to change a variable'
 ];
 
-// describe('Basic Css Introduction page', function() {
-//   it('renders', () => {
-//     cy.visit(locations.index);
-
-//     cy.title().should('eq', 'Basic CSS | freeCodeCamp.org');
-//   });
-
-//   it('renders a warning user about extensions', () => {
-//     cy.visit(locations.index);
-//     cy.get(selectors.warningMessage).contains(warningMessage);
-//   });
-
-//   it('renders a lesson index', () => {
-//     lessonNames.forEach(name => {
-//       cy.get(selectors.tableOfContents).contains('span', name);
-//     });
-//   });
-// });
-
 introductionPageTests(testTitle, pageTitle, locations, selectors, lessonNames);

--- a/cypress/integration/learn/responsive-web-design/basic-css/index.js
+++ b/cypress/integration/learn/responsive-web-design/basic-css/index.js
@@ -1,4 +1,8 @@
 /* global cy */
+import { introductionPageTests } from '../../introductionPages.js';
+
+const testTitle = 'Css';
+const pageTitle = 'Basic CSS | freeCodeCamp.org';
 
 const selectors = {
   tableOfContents: '.intro-toc',
@@ -56,26 +60,23 @@ const lessonNames = [
   'Use a media query to change a variable'
 ];
 
-const warningMessage =
-  'Note: Some browser extensions may interfere with elements on the page. ' +
-  'If the tests fail, try disabling your extensions for the most reliable ' +
-  'experience.';
+// describe('Basic Css Introduction page', function() {
+//   it('renders', () => {
+//     cy.visit(locations.index);
 
-describe('Basic Css Introduction page', function() {
-  it('renders', () => {
-    cy.visit(locations.index);
+//     cy.title().should('eq', 'Basic CSS | freeCodeCamp.org');
+//   });
 
-    cy.title().should('eq', 'Basic CSS | freeCodeCamp.org');
-  });
+//   it('renders a warning user about extensions', () => {
+//     cy.visit(locations.index);
+//     cy.get(selectors.warningMessage).contains(warningMessage);
+//   });
 
-  it('renders a warning user about extensions', () => {
-    cy.visit(locations.index);
-    cy.get(selectors.warningMessage).contains(warningMessage);
-  });
+//   it('renders a lesson index', () => {
+//     lessonNames.forEach(name => {
+//       cy.get(selectors.tableOfContents).contains('span', name);
+//     });
+//   });
+// });
 
-  it('renders a lesson index', () => {
-    lessonNames.forEach(name => {
-      cy.get(selectors.tableOfContents).contains('span', name);
-    });
-  });
-});
+introductionPageTests(testTitle, pageTitle, locations, selectors, lessonNames);

--- a/cypress/integration/learn/responsive-web-design/basic-html/index.js
+++ b/cypress/integration/learn/responsive-web-design/basic-html/index.js
@@ -1,0 +1,75 @@
+/* global cy */
+import { introductionPageTests } from '../../introductionPages.js';
+
+const testTitle = 'HTML & HTML5';
+const pageTitle = 'Basic HTML and HTML5 | freeCodeCamp.org';
+
+const selectors = {
+  tableOfContents: '.intro-toc'
+  // warningMessage: '.flash-message-enter-active'
+  // pageTitle: '.intro-layout h2'
+};
+
+const locations = {
+  index: '/learn/responsive-web-design/basic-html-and-html5/'
+};
+
+const lessonNames = [
+  'Say Hello to HTML Elements',
+  'Headline with the h2 Element',
+  'Inform with the Paragraph Element',
+  'Fill in the Blank with Placeholder Text',
+  'Uncomment HTML',
+  'Comment out HTML',
+  'Delete HTML Elements',
+  'Introduction to HTML5 Elements',
+  'Add Images to Your Website',
+  'Link to External Pages with Anchor Elements',
+  'Link to Internal Sections of a Page with Anchor Elements',
+  'Nest an Anchor Element within a Paragraph',
+  'Make Dead Links Using the Hash Symbol',
+  'Turn an Image into a Link',
+  'Create a Bulleted Unordered List',
+  'Create an Ordered List',
+  'Create a Text Field',
+  'Add Placeholder Text to a Text Field',
+  'Create a Form Element',
+  'Add a Submit Button to a Form',
+  'Use HTML5 to Require a Field',
+  'Create a Set of Radio Buttons',
+  'Create a Set of Checkboxes',
+  'Use the value attribute with Radio Buttons and Checkboxes',
+  'Check Radio Buttons and Checkboxes by Default',
+  'Nest Many Elements within a Single div Element',
+  'Declare the Doctype of an HTML Document',
+  'Define the Head and Body of an HTML Document'
+];
+
+// const titleName = 'Introduction to Basic HTML & HTML5';
+
+// const warningMessage =
+//   'Note: Some browser extensions may interfere with elements on the page. ' +
+//   'If the tests fail, try disabling your extensions for the most reliable ' +
+//   'experience.';
+
+// describe('Basic HTML & HTML5 Introduction page', function() {
+//   it('renders', () => {
+//     cy.visit(locations.index);
+
+//     cy.title().should('eq', 'Basic HTML and HTML5 | freeCodeCamp.org');
+//   });
+
+//   //   it('renders a warning user about extensions', () => {
+//   //     cy.visit(locations.index);
+//   //     cy.get(selectors.warningMessage).contains(warningMessage);
+//   //   });
+
+//   it('renders a lesson index', () => {
+//     cy.get(selectors.pageTitle).contains(titleName);
+//     lessonNames.forEach(name => {
+//       cy.get(selectors.tableOfContents).contains('span', name);
+//     });
+//   });
+// });
+
+introductionPageTests(testTitle, pageTitle, locations, selectors, lessonNames);

--- a/cypress/integration/learn/responsive-web-design/basic-html/index.js
+++ b/cypress/integration/learn/responsive-web-design/basic-html/index.js
@@ -6,8 +6,6 @@ const pageTitle = 'Basic HTML and HTML5 | freeCodeCamp.org';
 
 const selectors = {
   tableOfContents: '.intro-toc'
-  // warningMessage: '.flash-message-enter-active'
-  // pageTitle: '.intro-layout h2'
 };
 
 const locations = {
@@ -44,32 +42,5 @@ const lessonNames = [
   'Declare the Doctype of an HTML Document',
   'Define the Head and Body of an HTML Document'
 ];
-
-// const titleName = 'Introduction to Basic HTML & HTML5';
-
-// const warningMessage =
-//   'Note: Some browser extensions may interfere with elements on the page. ' +
-//   'If the tests fail, try disabling your extensions for the most reliable ' +
-//   'experience.';
-
-// describe('Basic HTML & HTML5 Introduction page', function() {
-//   it('renders', () => {
-//     cy.visit(locations.index);
-
-//     cy.title().should('eq', 'Basic HTML and HTML5 | freeCodeCamp.org');
-//   });
-
-//   //   it('renders a warning user about extensions', () => {
-//   //     cy.visit(locations.index);
-//   //     cy.get(selectors.warningMessage).contains(warningMessage);
-//   //   });
-
-//   it('renders a lesson index', () => {
-//     cy.get(selectors.pageTitle).contains(titleName);
-//     lessonNames.forEach(name => {
-//       cy.get(selectors.tableOfContents).contains('span', name);
-//     });
-//   });
-// });
 
 introductionPageTests(testTitle, pageTitle, locations, selectors, lessonNames);


### PR DESCRIPTION
I have moved the test code from cypress/integration/learn/responsive-web-design/basic-css/index.js into a new file, cypress/integration/learn/introductionPages.js, and export it as a module so I can use it in the html introduction page. 
The files in the responsive-web-design folder now only contain the data that needs to be tested, plus the call to the function containing the tests. 
We can keep it like this, or have one single file that loads all of the data and runs all the tests in succession. 
There is a warning message about extensions that appears only in the CSS introduction page, I'm not sure why.
